### PR TITLE
Move to sequential integration tests

### DIFF
--- a/programs/perpetuals/tests/native/main.rs
+++ b/programs/perpetuals/tests/native/main.rs
@@ -1,3 +1,14 @@
 pub mod instructions;
 pub mod tests_suite;
 pub mod utils;
+
+#[tokio::test]
+pub async fn test_integration() {
+    tests_suite::basic_interactions().await;
+    
+    tests_suite::swap::insuffisient_fund().await;
+
+    tests_suite::add_remove_liquidity::fixed_fees().await;
+    tests_suite::add_remove_liquidity::insuffisient_fund().await;
+    tests_suite::add_remove_liquidity::min_max_ratio().await;
+}

--- a/programs/perpetuals/tests/native/tests_suite/add_remove_liquidity/fixed_fees.rs
+++ b/programs/perpetuals/tests/native/tests_suite/add_remove_liquidity/fixed_fees.rs
@@ -26,7 +26,6 @@ const KEYPAIRS_COUNT: usize = 7;
 
 const USDC_DECIMALS: u8 = 6;
 
-#[tokio::test]
 pub async fn fixed_fees() {
     let mut program_test = ProgramTest::default();
 

--- a/programs/perpetuals/tests/native/tests_suite/add_remove_liquidity/insuffisient_fund.rs
+++ b/programs/perpetuals/tests/native/tests_suite/add_remove_liquidity/insuffisient_fund.rs
@@ -23,7 +23,6 @@ const KEYPAIRS_COUNT: usize = 7;
 const USDC_DECIMALS: u8 = 6;
 const ETH_DECIMALS: u8 = 9;
 
-#[tokio::test]
 pub async fn insuffisient_fund() {
     let mut program_test = ProgramTest::default();
 

--- a/programs/perpetuals/tests/native/tests_suite/add_remove_liquidity/min_max_ratio.rs
+++ b/programs/perpetuals/tests/native/tests_suite/add_remove_liquidity/min_max_ratio.rs
@@ -23,7 +23,6 @@ const KEYPAIRS_COUNT: usize = 7;
 const USDC_DECIMALS: u8 = 6;
 const ETH_DECIMALS: u8 = 9;
 
-#[tokio::test]
 pub async fn min_max_ratio() {
     let mut program_test = ProgramTest::default();
 

--- a/programs/perpetuals/tests/native/tests_suite/basic_interactions.rs
+++ b/programs/perpetuals/tests/native/tests_suite/basic_interactions.rs
@@ -29,7 +29,6 @@ const KEYPAIRS_COUNT: usize = 9;
 const USDC_DECIMALS: u8 = 6;
 const ETH_DECIMALS: u8 = 9;
 
-#[tokio::test]
 pub async fn basic_interactions() {
     let mut program_test = ProgramTest::default();
 

--- a/programs/perpetuals/tests/native/tests_suite/swap/insuffisient_fund.rs
+++ b/programs/perpetuals/tests/native/tests_suite/swap/insuffisient_fund.rs
@@ -23,7 +23,6 @@ const KEYPAIRS_COUNT: usize = 8;
 const USDC_DECIMALS: u8 = 6;
 const ETH_DECIMALS: u8 = 9;
 
-#[tokio::test]
 pub async fn insuffisient_fund() {
     let mut program_test = ProgramTest::default();
 


### PR DESCRIPTION
## Issue

It happens that transaction fails with exceeded deadline error after 60s.

Fails less often when tests are run with `--test-threads=1` 

--------

## Soluce

Re-execute the transaction up to 5 times.

--------

## TODO: Improvement Idea

- Tx takes 60s to get rejected. Makes integration test very long when deadline error happens.
