### PR TITLE
Add WithdrawSolFees instruction

### DIFF
--- a/programs/perpetuals/src/instructions.rs
+++ b/programs/perpetuals/src/instructions.rs
@@ -9,6 +9,7 @@ pub mod set_custody_config;
 pub mod set_permissions;
 pub mod upgrade_custody;
 pub mod withdraw_fees;
+pub mod withdraw_sol_fees;
 
 // test instructions
 pub mod set_test_oracle_price;
@@ -44,6 +45,7 @@ pub use set_custody_config::*;
 pub use set_permissions::*;
 pub use upgrade_custody::*;
 pub use withdraw_fees::*;
+pub use withdraw_sol_fees::*;
 
 pub use set_test_oracle_price::*;
 pub use set_test_time::*;

--- a/programs/perpetuals/src/instructions/withdraw_sol_fees.rs
+++ b/programs/perpetuals/src/instructions/withdraw_sol_fees.rs
@@ -1,0 +1,104 @@
+//! WithdrawSolFees instruction handler
+
+use {
+    crate::{
+        math,
+        state::{
+            multisig::{AdminInstruction, Multisig},
+            perpetuals::Perpetuals,
+        },
+    },
+    anchor_lang::prelude::*,
+    solana_program::sysvar,
+};
+
+#[derive(Accounts)]
+pub struct WithdrawSolFees<'info> {
+    #[account()]
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"multisig"],
+        bump = multisig.load()?.bump
+    )]
+    pub multisig: AccountLoader<'info, Multisig>,
+
+    /// CHECK: empty PDA, authority for token accounts
+    #[account(
+        seeds = [b"transfer_authority"],
+        bump = perpetuals.transfer_authority_bump
+    )]
+    pub transfer_authority: AccountInfo<'info>,
+
+    #[account(
+        seeds = [b"perpetuals"],
+        bump = perpetuals.perpetuals_bump
+    )]
+    pub perpetuals: Box<Account<'info, Perpetuals>>,
+
+    /// CHECK: SOL fees receiving account
+    #[account(
+        mut,
+        constraint = receiving_account.data_is_empty()
+    )]
+    pub receiving_account: AccountInfo<'info>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct WithdrawSolFeesParams {
+    pub amount: u64,
+}
+
+pub fn withdraw_sol_fees<'info>(
+    ctx: Context<'_, '_, '_, 'info, WithdrawSolFees<'info>>,
+    params: &WithdrawSolFeesParams,
+) -> Result<u8> {
+    // validate inputs
+    if params.amount == 0 {
+        return Err(ProgramError::InvalidArgument.into());
+    }
+
+    // validate signatures
+    let mut multisig = ctx.accounts.multisig.load_mut()?;
+
+    let signatures_left = multisig.sign_multisig(
+        &ctx.accounts.admin,
+        &Multisig::get_account_infos(&ctx)[1..],
+        &Multisig::get_instruction_data(AdminInstruction::WithdrawSolFees, params)?,
+    )?;
+    if signatures_left > 0 {
+        msg!(
+            "Instruction has been signed but more signatures are required: {}",
+            signatures_left
+        );
+        return Ok(signatures_left);
+    }
+
+    // transfer sol fees from the custody to the receiver
+    let balance = ctx.accounts.transfer_authority.try_lamports()?;
+    let min_balance = sysvar::rent::Rent::get().unwrap().minimum_balance(0);
+    let available_balance = if balance > min_balance {
+        math::checked_sub(balance, min_balance)?
+    } else {
+        0
+    };
+
+    msg!(
+        "Withdraw SOL fees: {} / {}",
+        params.amount,
+        available_balance
+    );
+
+    if available_balance < params.amount {
+        return Err(ProgramError::InsufficientFunds.into());
+    }
+
+    Perpetuals::transfer_sol_from_owned(
+        ctx.accounts.transfer_authority.to_account_info(),
+        ctx.accounts.receiving_account.to_account_info(),
+        params.amount,
+    )?;
+
+    Ok(0)
+}

--- a/programs/perpetuals/src/lib.rs
+++ b/programs/perpetuals/src/lib.rs
@@ -89,6 +89,13 @@ pub mod perpetuals {
         instructions::withdraw_fees(ctx, &params)
     }
 
+    pub fn withdraw_sol_fees<'info>(
+        ctx: Context<'_, '_, '_, 'info, WithdrawSolFees<'info>>,
+        params: WithdrawSolFeesParams,
+    ) -> Result<u8> {
+        instructions::withdraw_sol_fees(ctx, &params)
+    }
+
     pub fn upgrade_custody<'info>(
         ctx: Context<'_, '_, '_, 'info, UpgradeCustody<'info>>,
         params: UpgradeCustodyParams,

--- a/programs/perpetuals/src/state/multisig.rs
+++ b/programs/perpetuals/src/state/multisig.rs
@@ -32,6 +32,7 @@ pub enum AdminInstruction {
     SetPermissions,
     SetBorrowRate,
     WithdrawFees,
+    WithdrawSolFees,
     SetTestOraclePrice,
     SetTestTime,
     UpgradeCustody,

--- a/programs/perpetuals/tests/anchor/test_client.ts
+++ b/programs/perpetuals/tests/anchor/test_client.ts
@@ -605,13 +605,7 @@ export class TestClient {
     }
   };
 
-  withdrawFees = async (
-    tokenAmount: typeof BN,
-    solAmount: typeof BN,
-    custody,
-    receivingTokenAccount,
-    receivingSolAccount
-  ) => {
+  withdrawFees = async (amount: typeof BN, custody, receivingTokenAccount) => {
     let multisig = await this.program.account.multisig.fetch(
       this.multisig.publicKey
     );
@@ -619,8 +613,7 @@ export class TestClient {
       try {
         await this.program.methods
           .withdrawFees({
-            tokenAmount,
-            solAmount,
+            amount,
           })
           .accounts({
             admin: this.admins[i].publicKey,
@@ -631,8 +624,35 @@ export class TestClient {
             custody: custody.custody,
             custodyTokenAccount: custody.tokenAccount,
             receivingTokenAccount: receivingTokenAccount,
-            receivingSolAccount: receivingSolAccount,
             tokenProgram: spl.TOKEN_PROGRAM_ID,
+          })
+          .signers([this.admins[i]])
+          .rpc();
+      } catch (err) {
+        if (this.printErrors) {
+          console.log(err);
+        }
+        throw err;
+      }
+    }
+  };
+
+  withdrawSolFees = async (amount: typeof BN, custody, receivingAccount) => {
+    let multisig = await this.program.account.multisig.fetch(
+      this.multisig.publicKey
+    );
+    for (let i = 0; i < multisig.minSignatures; ++i) {
+      try {
+        await this.program.methods
+          .withdrawSolFees({
+            amount,
+          })
+          .accounts({
+            admin: this.admins[i].publicKey,
+            multisig: this.multisig.publicKey,
+            transferAuthority: this.authority.publicKey,
+            perpetuals: this.perpetuals.publicKey,
+            receivingAccount: receivingAccount,
           })
           .signers([this.admins[i]])
           .rpc();


### PR DESCRIPTION
WithdrawFees instruction won't work if all custodies have been removed. While protocol fees can't be locked (because a custody can't be removed unless it is empty) rent SOL that is collected upon pool/custody removal can be stuck in transfer_authority. This PR splits WithdrawFees in two separate instructions, the new one can be executed w/o providing a pool or custody.