### PR TITLE
Configure rust fmt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+diff=$(cargo +nightly fmt -- --check)
+result=$?
+
+if [[ ${result} -ne 0 ]] ; then
+    cat <<\EOF
+There are some code style issues, run `cargo +nightly fmt` first.
+EOF
+    exit 1
+fi
+
+exit 0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
+    ],
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Solana Perpetuals protocol is an open-source implementation of a non-custodial d
 3. Install the latest Rust stable from <https://rustup.rs/>. If you already have Rust, run `rustup update` to get the latest version.
 4. Install the latest Anchor framework from <https://www.anchor-lang.com/docs/installation>. If you already have Anchor, run `avm update` to get the latest version.
 
+Rustfmt is used to format the code. It requires `nightly` features to be activated.
+5. Install `nightly` rust toolchain. <https://rust-lang.github.io/rustup/installation/index.html#installing-nightly>
+
+#### [Optionnal] Vscode setup
+
+1. Install `rust-analyzer` extension
+2. If formatting doesn't work, make sure that `rust-analyzer.rustfmt.extraArgs` is set to `+nightly`
+
 ### Build
 
 First, generate a new key for the program address with `solana-keygen new -o <PROG_ID_JSON>`. Then replace the existing program ID with the newly generated address in Anchor.toml and `programs/perpetuals/src/lib.rs`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Solana Perpetuals protocol is an open-source implementation of a non-custodial d
 
 Rustfmt is used to format the code. It requires `nightly` features to be activated.
 5. Install `nightly` rust toolchain. <https://rust-lang.github.io/rustup/installation/index.html#installing-nightly>
+6. Execute `git config core.hooksPath .githooks` to activate pre-commit hooks
 
 #### [Optionnal] Vscode setup
 

--- a/programs/perpetuals/src/instructions.rs
+++ b/programs/perpetuals/src/instructions.rs
@@ -37,37 +37,14 @@ pub mod remove_liquidity;
 pub mod swap;
 
 // bring everything in scope
-pub use add_custody::*;
-pub use add_pool::*;
-pub use init::*;
-pub use remove_custody::*;
-pub use remove_pool::*;
-pub use set_admin_signers::*;
-pub use set_custody_config::*;
-pub use set_permissions::*;
-pub use upgrade_custody::*;
-pub use withdraw_fees::*;
-pub use withdraw_sol_fees::*;
-
-pub use set_test_oracle_price::*;
-pub use set_test_time::*;
-pub use test_init::*;
-
-pub use add_collateral::*;
-pub use add_liquidity::*;
-pub use close_position::*;
-pub use get_add_liquidity_amount_and_fee::*;
-pub use get_assets_under_management::*;
-pub use get_entry_price_and_fee::*;
-pub use get_exit_price_and_fee::*;
-pub use get_liquidation_price::*;
-pub use get_liquidation_state::*;
-pub use get_oracle_price::*;
-pub use get_pnl::*;
-pub use get_remove_liquidity_amount_and_fee::*;
-pub use get_swap_amount_and_fees::*;
-pub use liquidate::*;
-pub use open_position::*;
-pub use remove_collateral::*;
-pub use remove_liquidity::*;
-pub use swap::*;
+pub use {
+    add_collateral::*, add_custody::*, add_liquidity::*, add_pool::*, close_position::*,
+    get_add_liquidity_amount_and_fee::*, get_assets_under_management::*,
+    get_entry_price_and_fee::*, get_exit_price_and_fee::*, get_liquidation_price::*,
+    get_liquidation_state::*, get_oracle_price::*, get_pnl::*,
+    get_remove_liquidity_amount_and_fee::*, get_swap_amount_and_fees::*, init::*, liquidate::*,
+    open_position::*, remove_collateral::*, remove_custody::*, remove_liquidity::*, remove_pool::*,
+    set_admin_signers::*, set_custody_config::*, set_permissions::*, set_test_oracle_price::*,
+    set_test_time::*, swap::*, test_init::*, upgrade_custody::*, withdraw_fees::*,
+    withdraw_sol_fees::*,
+};

--- a/programs/perpetuals/src/state/pool.rs
+++ b/programs/perpetuals/src/state/pool.rs
@@ -950,11 +950,13 @@ impl Pool {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::state::{
-        custody::{BorrowRateParams, Fees, OracleParams, PricingParams},
-        oracle::OracleType,
-        perpetuals::Permissions,
+    use {
+        super::*,
+        crate::state::{
+            custody::{BorrowRateParams, Fees, OracleParams, PricingParams},
+            oracle::OracleType,
+            perpetuals::Permissions,
+        },
     };
 
     fn get_fixture() -> (Pool, Custody, Position, OraclePrice, OraclePrice) {

--- a/programs/perpetuals/tests/native/instructions/mod.rs
+++ b/programs/perpetuals/tests/native/instructions/mod.rs
@@ -10,14 +10,8 @@ pub mod test_set_custody_config;
 pub mod test_set_test_oracle_price;
 pub mod test_swap;
 
-pub use test_add_custody::*;
-pub use test_add_liquidity::*;
-pub use test_add_pool::*;
-pub use test_close_position::*;
-pub use test_init::*;
-pub use test_liquidate::*;
-pub use test_open_position::*;
-pub use test_remove_liquidity::*;
-pub use test_set_custody_config::*;
-pub use test_set_test_oracle_price::*;
-pub use test_swap::*;
+pub use {
+    test_add_custody::*, test_add_liquidity::*, test_add_pool::*, test_close_position::*,
+    test_init::*, test_liquidate::*, test_open_position::*, test_remove_liquidity::*,
+    test_set_custody_config::*, test_set_test_oracle_price::*, test_swap::*,
+};

--- a/programs/perpetuals/tests/native/instructions/test_add_custody.rs
+++ b/programs/perpetuals/tests/native/instructions/test_add_custody.rs
@@ -8,8 +8,7 @@ use {
         instructions::AddCustodyParams,
         state::{custody::Custody, multisig::Multisig, pool::Pool},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_add_liquidity.rs
+++ b/programs/perpetuals/tests/native/instructions/test_add_liquidity.rs
@@ -9,8 +9,7 @@ use {
         instructions::AddLiquidityParams,
         state::{custody::Custody, pool::Pool},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_add_pool.rs
+++ b/programs/perpetuals/tests/native/instructions/test_add_pool.rs
@@ -5,8 +5,7 @@ use {
         instructions::AddPoolParams,
         state::{multisig::Multisig, perpetuals::Perpetuals, pool::Pool},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
     std::str::FromStr,
 };

--- a/programs/perpetuals/tests/native/instructions/test_close_position.rs
+++ b/programs/perpetuals/tests/native/instructions/test_close_position.rs
@@ -3,8 +3,7 @@ use {
     anchor_lang::{prelude::Pubkey, ToAccountMetas},
     bonfida_test_utils::ProgramTestContextExt,
     perpetuals::{instructions::ClosePositionParams, state::custody::Custody},
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_init.rs
+++ b/programs/perpetuals/tests/native/instructions/test_init.rs
@@ -5,8 +5,7 @@ use {
         instructions::InitParams,
         state::{multisig::Multisig, perpetuals::Perpetuals},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_liquidate.rs
+++ b/programs/perpetuals/tests/native/instructions/test_liquidate.rs
@@ -2,10 +2,11 @@ use {
     crate::utils::{self, pda},
     anchor_lang::{prelude::Pubkey, ToAccountMetas},
     bonfida_test_utils::ProgramTestContextExt,
-    perpetuals::state::custody::Custody,
-    perpetuals::{instructions::LiquidateParams, state::position::Position},
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    perpetuals::{
+        instructions::LiquidateParams,
+        state::{custody::Custody, position::Position},
+    },
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_open_position.rs
+++ b/programs/perpetuals/tests/native/instructions/test_open_position.rs
@@ -6,8 +6,7 @@ use {
         instructions::OpenPositionParams,
         state::{custody::Custody, perpetuals::Perpetuals, position::Position},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_remove_liquidity.rs
+++ b/programs/perpetuals/tests/native/instructions/test_remove_liquidity.rs
@@ -9,8 +9,7 @@ use {
         instructions::RemoveLiquidityParams,
         state::{custody::Custody, pool::Pool},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_set_custody_config.rs
+++ b/programs/perpetuals/tests/native/instructions/test_set_custody_config.rs
@@ -8,8 +8,7 @@ use {
         instructions::SetCustodyConfigParams,
         state::{custody::Custody, multisig::Multisig},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_set_test_oracle_price.rs
+++ b/programs/perpetuals/tests/native/instructions/test_set_test_oracle_price.rs
@@ -8,8 +8,7 @@ use {
         instructions::SetTestOraclePriceParams,
         state::{multisig::Multisig, oracle::TestOracle},
     },
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/instructions/test_swap.rs
+++ b/programs/perpetuals/tests/native/instructions/test_swap.rs
@@ -3,8 +3,7 @@ use {
     anchor_lang::{prelude::Pubkey, ToAccountMetas},
     bonfida_test_utils::ProgramTestContextExt,
     perpetuals::{instructions::SwapParams, state::custody::Custody},
-    solana_program_test::BanksClientError,
-    solana_program_test::ProgramTestContext,
+    solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
 };
 

--- a/programs/perpetuals/tests/native/tests_suite/liquidity/fixed_fees.rs
+++ b/programs/perpetuals/tests/native/tests_suite/liquidity/fixed_fees.rs
@@ -4,12 +4,14 @@ use {
         utils::{self, fixtures},
     },
     bonfida_test_utils::ProgramTestExt,
-    perpetuals::instructions::AddLiquidityParams,
-    perpetuals::instructions::RemoveLiquidityParams,
-    perpetuals::state::custody::Custody,
-    perpetuals::state::custody::{Fees, FeesMode},
-    perpetuals::state::perpetuals::Perpetuals,
-    perpetuals::state::pool::Pool,
+    perpetuals::{
+        instructions::{AddLiquidityParams, RemoveLiquidityParams},
+        state::{
+            custody::{Custody, Fees, FeesMode},
+            perpetuals::Perpetuals,
+            pool::Pool,
+        },
+    },
     solana_program_test::ProgramTest,
     solana_sdk::signer::Signer,
 };

--- a/programs/perpetuals/tests/native/tests_suite/liquidity/insuffisient_fund.rs
+++ b/programs/perpetuals/tests/native/tests_suite/liquidity/insuffisient_fund.rs
@@ -4,8 +4,7 @@ use {
         utils::{self, fixtures},
     },
     bonfida_test_utils::ProgramTestExt,
-    perpetuals::instructions::AddLiquidityParams,
-    perpetuals::instructions::RemoveLiquidityParams,
+    perpetuals::instructions::{AddLiquidityParams, RemoveLiquidityParams},
     solana_program_test::ProgramTest,
     solana_sdk::signer::Signer,
 };

--- a/programs/perpetuals/tests/native/tests_suite/liquidity/min_max_ratio.rs
+++ b/programs/perpetuals/tests/native/tests_suite/liquidity/min_max_ratio.rs
@@ -4,8 +4,7 @@ use {
         utils::{self, fixtures},
     },
     bonfida_test_utils::ProgramTestExt,
-    perpetuals::instructions::AddLiquidityParams,
-    perpetuals::instructions::RemoveLiquidityParams,
+    perpetuals::instructions::{AddLiquidityParams, RemoveLiquidityParams},
     solana_program_test::ProgramTest,
     solana_sdk::signer::Signer,
 };

--- a/programs/perpetuals/tests/native/tests_suite/liquidity/mod.rs
+++ b/programs/perpetuals/tests/native/tests_suite/liquidity/mod.rs
@@ -2,6 +2,4 @@ pub mod fixed_fees;
 pub mod insuffisient_fund;
 pub mod min_max_ratio;
 
-pub use fixed_fees::*;
-pub use insuffisient_fund::*;
-pub use min_max_ratio::*;
+pub use {fixed_fees::*, insuffisient_fund::*, min_max_ratio::*};

--- a/programs/perpetuals/tests/native/tests_suite/mod.rs
+++ b/programs/perpetuals/tests/native/tests_suite/mod.rs
@@ -3,7 +3,4 @@ pub mod liquidity;
 pub mod position;
 pub mod swap;
 
-pub use basic_interactions::*;
-pub use liquidity::*;
-pub use position::*;
-pub use swap::*;
+pub use {basic_interactions::*, liquidity::*, position::*, swap::*};

--- a/programs/perpetuals/tests/native/tests_suite/position/liquidate_position.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/liquidate_position.rs
@@ -4,10 +4,9 @@ use {
         utils::{self, fixtures},
     },
     bonfida_test_utils::ProgramTestExt,
-    perpetuals::state::custody::PricingParams,
     perpetuals::{
         instructions::{OpenPositionParams, SetTestOraclePriceParams},
-        state::position::Side,
+        state::{custody::PricingParams, position::Side},
     },
     solana_program_test::ProgramTest,
     solana_sdk::signer::Signer,

--- a/programs/perpetuals/tests/native/tests_suite/position/max_user_profit.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/max_user_profit.rs
@@ -4,9 +4,10 @@ use {
         utils::{self, fixtures},
     },
     bonfida_test_utils::ProgramTestExt,
-    perpetuals::instructions::{ClosePositionParams, SetTestOraclePriceParams},
-    perpetuals::state::custody::PricingParams,
-    perpetuals::{instructions::OpenPositionParams, state::position::Side},
+    perpetuals::{
+        instructions::{ClosePositionParams, OpenPositionParams, SetTestOraclePriceParams},
+        state::{custody::PricingParams, position::Side},
+    },
     solana_program_test::ProgramTest,
     solana_sdk::signer::Signer,
 };

--- a/programs/perpetuals/tests/native/tests_suite/position/min_max_leverage.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/min_max_leverage.rs
@@ -4,8 +4,10 @@ use {
         utils::{self, fixtures},
     },
     bonfida_test_utils::ProgramTestExt,
-    perpetuals::state::custody::PricingParams,
-    perpetuals::{instructions::OpenPositionParams, state::position::Side},
+    perpetuals::{
+        instructions::OpenPositionParams,
+        state::{custody::PricingParams, position::Side},
+    },
     solana_program_test::ProgramTest,
     solana_sdk::signer::Signer,
 };

--- a/programs/perpetuals/tests/native/tests_suite/position/mod.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/mod.rs
@@ -2,6 +2,4 @@ pub mod liquidate_position;
 pub mod max_user_profit;
 pub mod min_max_leverage;
 
-pub use liquidate_position::*;
-pub use max_user_profit::*;
-pub use min_max_leverage::*;
+pub use {liquidate_position::*, max_user_profit::*, min_max_leverage::*};

--- a/programs/perpetuals/tests/native/utils/fixtures.rs
+++ b/programs/perpetuals/tests/native/utils/fixtures.rs
@@ -2,11 +2,10 @@
 
 use {
     anchor_lang::prelude::Pubkey,
-    perpetuals::state::custody::BorrowRateParams,
     perpetuals::{
         instructions::InitParams,
         state::{
-            custody::{Fees, FeesMode, OracleParams, PricingParams},
+            custody::{BorrowRateParams, Fees, FeesMode, OracleParams, PricingParams},
             oracle::OracleType,
             perpetuals::Permissions,
         },

--- a/programs/perpetuals/tests/native/utils/mod.rs
+++ b/programs/perpetuals/tests/native/utils/mod.rs
@@ -3,6 +3,4 @@ pub mod pda;
 #[allow(clippy::module_inception)]
 pub mod utils;
 
-pub use fixtures::*;
-pub use pda::*;
-pub use utils::*;
+pub use {fixtures::*, pda::*, utils::*};

--- a/programs/perpetuals/tests/native/utils/utils.rs
+++ b/programs/perpetuals/tests/native/utils/utils.rs
@@ -11,7 +11,7 @@ use {
         math,
         state::{
             custody::{BorrowRateParams, Custody, Fees, PricingParams},
-            perpetuals::Permissions,
+            perpetuals::{Permissions, Perpetuals},
             pool::TokenRatios,
         },
     },

--- a/programs/perpetuals/tests/native/utils/utils.rs
+++ b/programs/perpetuals/tests/native/utils/utils.rs
@@ -4,24 +4,24 @@ use {
     anchor_lang::{prelude::*, InstructionData},
     anchor_spl::token::spl_token,
     bonfida_test_utils::ProgramTestContextExt,
-    perpetuals::state::custody::BorrowRateParams,
     perpetuals::{
         instructions::{
             AddCustodyParams, AddLiquidityParams, SetCustodyConfigParams, SetTestOraclePriceParams,
         },
+        math,
         state::{
-            custody::{Custody, Fees, PricingParams},
+            custody::{BorrowRateParams, Custody, Fees, PricingParams},
             perpetuals::Permissions,
             pool::TokenRatios,
         },
     },
-    perpetuals::{math, state::perpetuals::Perpetuals},
     solana_program::{bpf_loader_upgradeable, program_pack::Pack, stake_history::Epoch},
-    solana_program_test::BanksClientError,
-    solana_program_test::{read_file, ProgramTest, ProgramTestContext},
+    solana_program_test::{read_file, BanksClientError, ProgramTest, ProgramTestContext},
     solana_sdk::{account, signature::Keypair, signer::Signer, signers::Signers},
-    std::ops::{Div, Mul},
-    std::path::Path,
+    std::{
+        ops::{Div, Mul},
+        path::Path,
+    },
 };
 
 pub const ANCHOR_DISCRIMINATOR_SIZE: usize = 8;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+imports_granularity = "One"
+group_imports = "One"
+use_field_init_shorthand = true


### PR DESCRIPTION
Setup new `rustfmt.toml` file to specify custom rules:

```
imports_granularity = "One"
group_imports = "One"
use_field_init_shorthand = true
```

See:
- https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#imports_granularity
- https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#group_imports
- https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#use_field_init_shorthand

To run:

```
cargo +nightly fmt
```

What changes:

- Merge all imports into a single use statement as long as they have the same visibility.
- Discard existing import groups, and create a single group for everything.
- Use field initialize shorthand if possible.