### PR TITLE
Check leverage using average price

### DIFF
--- a/programs/perpetuals/src/instructions/add_collateral.rs
+++ b/programs/perpetuals/src/instructions/add_collateral.rs
@@ -157,7 +157,6 @@ pub fn add_collateral(ctx: Context<AddCollateral>, params: &AddCollateralParams)
         pool.check_leverage(
             token_id,
             position,
-            &token_price,
             &token_ema_price,
             custody,
             curtime,

--- a/programs/perpetuals/src/instructions/get_liquidation_state.rs
+++ b/programs/perpetuals/src/instructions/get_liquidation_state.rs
@@ -58,15 +58,6 @@ pub fn get_liquidation_state(
     let custody = ctx.accounts.custody.as_mut();
     let curtime = ctx.accounts.perpetuals.get_time()?;
 
-    let token_price = OraclePrice::new_from_oracle(
-        custody.oracle.oracle_type,
-        &ctx.accounts.custody_oracle_account.to_account_info(),
-        custody.oracle.max_price_error,
-        custody.oracle.max_price_age_sec,
-        curtime,
-        false,
-    )?;
-
     let token_ema_price = OraclePrice::new_from_oracle(
         custody.oracle.oracle_type,
         &ctx.accounts.custody_oracle_account.to_account_info(),
@@ -79,7 +70,6 @@ pub fn get_liquidation_state(
     if ctx.accounts.pool.check_leverage(
         ctx.accounts.pool.get_token_id(&custody.key())?,
         &ctx.accounts.position,
-        &token_price,
         &token_ema_price,
         custody,
         curtime,

--- a/programs/perpetuals/src/instructions/liquidate.rs
+++ b/programs/perpetuals/src/instructions/liquidate.rs
@@ -138,7 +138,6 @@ pub fn liquidate(ctx: Context<Liquidate>, _params: &LiquidateParams) -> Result<(
         !pool.check_leverage(
             token_id,
             position,
-            &token_price,
             &token_ema_price,
             custody,
             curtime,

--- a/programs/perpetuals/src/instructions/open_position.rs
+++ b/programs/perpetuals/src/instructions/open_position.rs
@@ -219,15 +219,7 @@ pub fn open_position(ctx: Context<OpenPosition>, params: &OpenPositionParams) ->
         PerpetualsError::InsufficientAmountReturned
     );
     require!(
-        pool.check_leverage(
-            token_id,
-            position,
-            &token_price,
-            &token_ema_price,
-            custody,
-            curtime,
-            true
-        )?,
+        pool.check_leverage(token_id, position, &token_ema_price, custody, curtime, true)?,
         PerpetualsError::MaxLeverage
     );
 

--- a/programs/perpetuals/src/instructions/remove_collateral.rs
+++ b/programs/perpetuals/src/instructions/remove_collateral.rs
@@ -169,7 +169,6 @@ pub fn remove_collateral(
         pool.check_leverage(
             token_id,
             position,
-            &token_price,
             &token_ema_price,
             custody,
             curtime,

--- a/programs/perpetuals/src/state/pool.rs
+++ b/programs/perpetuals/src/state/pool.rs
@@ -326,7 +326,6 @@ impl Pool {
         token_id: usize,
         position: &Position,
         token_price: &OraclePrice,
-        token_ema_price: &OraclePrice,
         custody: &Custody,
         curtime: i64,
     ) -> Result<u64> {
@@ -334,7 +333,7 @@ impl Pool {
             token_id,
             position,
             token_price,
-            token_ema_price,
+            token_price,
             custody,
             curtime,
             false,
@@ -364,19 +363,12 @@ impl Pool {
         token_id: usize,
         position: &Position,
         token_price: &OraclePrice,
-        token_ema_price: &OraclePrice,
         custody: &Custody,
         curtime: i64,
         initial: bool,
     ) -> Result<bool> {
-        let current_leverage = self.get_leverage(
-            token_id,
-            position,
-            token_price,
-            token_ema_price,
-            custody,
-            curtime,
-        )?;
+        let current_leverage =
+            self.get_leverage(token_id, position, token_price, custody, curtime)?;
 
         Ok(current_leverage <= custody.pricing.max_leverage
             && (!initial || current_leverage >= custody.pricing.min_initial_leverage))
@@ -1159,49 +1151,49 @@ mod test {
 
         assert_eq!(
             scale_f64(4.9043, Perpetuals::BPS_DECIMALS),
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
 
         position.price = scale(110, Perpetuals::PRICE_DECIMALS);
         assert_eq!(
             scale_f64(3.9385, Perpetuals::BPS_DECIMALS),
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
 
         position.price = scale(130, Perpetuals::PRICE_DECIMALS);
         assert_eq!(
             scale_f64(6.4977, Perpetuals::BPS_DECIMALS),
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
 
         position.price = scale(80, Perpetuals::PRICE_DECIMALS);
         assert_eq!(
             scale_f64(2.4758, Perpetuals::BPS_DECIMALS),
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
 
         position.price = scale(0, Perpetuals::PRICE_DECIMALS);
         assert_eq!(
             scale_f64(1.2439, Perpetuals::BPS_DECIMALS),
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
 
         position.price = scale(160, Perpetuals::PRICE_DECIMALS);
         assert_eq!(
             2564102,
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
 
         position.price = scale(180, Perpetuals::PRICE_DECIMALS);
         assert_eq!(
             u64::MAX,
-            pool.get_leverage(0, &position, &token_price, &token_ema_price, &custody, 0)
+            pool.get_leverage(0, &position, &token_ema_price, &custody, 0)
                 .unwrap()
         );
     }


### PR DESCRIPTION
An open position can be liquidated even if only a single price print led to the failed max leverage check. This PR forces leverage check to always use average price. Note that all other values that depend on oracle price will be computed as before.