### PR TITLE
Make sure amount of LP tokens cannot be gamed

### DIFF
--- a/programs/perpetuals/src/instructions/get_assets_under_management.rs
+++ b/programs/perpetuals/src/instructions/get_assets_under_management.rs
@@ -1,7 +1,10 @@
 //! GetAssetsUnderManagement instruction handler
 
 use {
-    crate::state::{perpetuals::Perpetuals, pool::Pool},
+    crate::state::{
+        perpetuals::Perpetuals,
+        pool::{AumCalcMode, Pool},
+    },
     anchor_lang::prelude::*,
 };
 
@@ -32,6 +35,7 @@ pub fn get_assets_under_management(
     _params: &GetAssetsUnderManagementParams,
 ) -> Result<u128> {
     ctx.accounts.pool.get_assets_under_management_usd(
+        AumCalcMode::EMA,
         ctx.remaining_accounts,
         ctx.accounts.perpetuals.get_time()?,
     )


### PR DESCRIPTION
amount of LP tokens received or burned depends on the assets under management calculation performed at that time. If token price is manipulated, that amount can be easily gamed. The proposed change introduces AumCalcMode that can specify if AUM calculation is performed based on max(token_price, token_ema_price), or min(token_price, token_ema_price), or just token_price. `add_liquidity` and `remove_liquidity` instructions are adjusted to use proper mode. 