### PR TITLE
Ensure proper token ratios

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,9 +1,9 @@
 [features]
 seeds = false
 [programs.localnet]
-perpetuals = "PERP9EeXeGnyEqGmxGSan4nGRAFNLwTufLJmiYsTJ8j"
+perpetuals = "PERP38nWNVRkULEKeNHyEyAwuQor2u6EnXZn3cMZCwS"
 [programs.devnet]
-perpetuals = "PERP9EeXeGnyEqGmxGSan4nGRAFNLwTufLJmiYsTJ8j"
+perpetuals = "PERP38nWNVRkULEKeNHyEyAwuQor2u6EnXZn3cMZCwS"
 
 [registry]
 url = "https://anchor.projectserum.com"

--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -82,7 +82,7 @@ async function addCustody(
     maxPayoffMult: new BN(10000),
     maxUtilization: new BN(10000),
     maxPositionLockedUsd: new BN(1000000000),
-    maxTotalLockedUsd: new BN(0),
+    maxTotalLockedUsd: new BN(1000000000),
   };
   let permissions = {
     allowSwap: true,
@@ -112,11 +112,14 @@ async function addCustody(
     slope2: new BN(120000),
     optimalUtilization: new BN(800000000),
   };
-  let ratios = {
+
+  let pool = await client.getPool(poolName);
+  pool.ratios.push({
     target: new BN(5000),
     min: new BN(10),
-    max: new BN(20000),
-  };
+    max: new BN(10000),
+  });
+  let ratios = client.adjustTokenRatios(pool.ratios);
 
   client.addCustody(
     poolName,
@@ -140,7 +143,11 @@ async function getCustodies(poolName: string) {
 }
 
 async function removeCustody(poolName: string, tokenMint: PublicKey) {
-  client.removeCustody(poolName, tokenMint);
+  let pool = await client.getPool(poolName);
+  pool.ratios.pop();
+  let ratios = client.adjustTokenRatios(pool.ratios);
+
+  client.removeCustody(poolName, tokenMint, ratios);
 }
 
 async function upgradeCustody(poolName: string, tokenMint: PublicKey) {

--- a/programs/perpetuals/src/error.rs
+++ b/programs/perpetuals/src/error.rs
@@ -32,6 +32,8 @@ pub enum PerpetualsError {
     InvalidPositionState,
     #[msg("Invalid perpetuals config")]
     InvalidPerpetualsConfig,
+    #[msg("Invalid pool config")]
+    InvalidPoolConfig,
     #[msg("Invalid custody config")]
     InvalidCustodyConfig,
     #[msg("Insufficient token amount returned")]

--- a/programs/perpetuals/src/instructions/add_pool.rs
+++ b/programs/perpetuals/src/instructions/add_pool.rs
@@ -1,10 +1,13 @@
 //! AddPool instruction handler
 
 use {
-    crate::state::{
-        multisig::{AdminInstruction, Multisig},
-        perpetuals::Perpetuals,
-        pool::Pool,
+    crate::{
+        error::PerpetualsError,
+        state::{
+            multisig::{AdminInstruction, Multisig},
+            perpetuals::Perpetuals,
+            pool::Pool,
+        },
     },
     anchor_lang::prelude::*,
     anchor_spl::token::{Mint, Token},
@@ -118,6 +121,10 @@ pub fn add_pool<'info>(
         .bumps
         .get("lp_token_mint")
         .ok_or(ProgramError::InvalidSeeds)?;
+
+    if !pool.validate() {
+        return err!(PerpetualsError::InvalidPoolConfig);
+    }
 
     perpetuals.pools.push(ctx.accounts.pool.key());
 

--- a/programs/perpetuals/src/instructions/remove_pool.rs
+++ b/programs/perpetuals/src/instructions/remove_pool.rs
@@ -78,7 +78,7 @@ pub fn remove_pool<'info>(
     }
 
     require!(
-        ctx.accounts.pool.tokens.is_empty(),
+        ctx.accounts.pool.custodies.is_empty(),
         PerpetualsError::InvalidPoolState
     );
 

--- a/programs/perpetuals/src/lib.rs
+++ b/programs/perpetuals/src/lib.rs
@@ -24,7 +24,7 @@ solana_security_txt::security_txt! {
     auditors: ""
 }
 
-declare_id!("PERP9EeXeGnyEqGmxGSan4nGRAFNLwTufLJmiYsTJ8j");
+declare_id!("PERP38nWNVRkULEKeNHyEyAwuQor2u6EnXZn3cMZCwS");
 
 #[program]
 pub mod perpetuals {

--- a/programs/perpetuals/src/state/pool.rs
+++ b/programs/perpetuals/src/state/pool.rs
@@ -22,25 +22,33 @@ pub enum AumCalcMode {
 }
 
 #[derive(Copy, Clone, PartialEq, AnchorSerialize, AnchorDeserialize, Default, Debug)]
-pub struct PoolToken {
-    pub custody: Pubkey,
-
-    // ratios have implied BPS_DECIMALS decimals
-    pub target_ratio: u64,
-    pub min_ratio: u64,
-    pub max_ratio: u64,
+pub struct TokenRatios {
+    pub target: u64,
+    pub min: u64,
+    pub max: u64,
 }
 
 #[account]
 #[derive(Default, Debug)]
 pub struct Pool {
     pub name: String,
-    pub tokens: Vec<PoolToken>,
+    pub custodies: Vec<Pubkey>,
+    pub ratios: Vec<TokenRatios>,
     pub aum_usd: u128,
 
     pub bump: u8,
     pub lp_token_bump: u8,
     pub inception_time: i64,
+}
+
+impl TokenRatios {
+    pub fn validate(&self) -> bool {
+        (self.target as u128) <= Perpetuals::BPS_POWER
+            && (self.min as u128) <= Perpetuals::BPS_POWER
+            && (self.max as u128) <= Perpetuals::BPS_POWER
+            && self.min <= self.target
+            && self.target <= self.max
+    }
 }
 
 /// Token Pool
@@ -50,10 +58,39 @@ pub struct Pool {
 impl Pool {
     pub const LEN: usize = 8 + std::mem::size_of::<Pool>();
 
+    pub fn validate(&self) -> bool {
+        for ratio in &self.ratios {
+            if !ratio.validate() {
+                return false;
+            }
+        }
+
+        // check target ratios add up to 1
+        if !self.ratios.is_empty()
+            && self
+                .ratios
+                .iter()
+                .map(|&x| (x.target as u128))
+                .sum::<u128>()
+                != Perpetuals::BPS_POWER
+        {
+            return false;
+        }
+
+        // check custodies are unique
+        for i in 1..self.custodies.len() {
+            if self.custodies[i..].contains(&self.custodies[i - 1]) {
+                return false;
+            }
+        }
+
+        !self.name.is_empty() && self.name.len() <= 64 && self.custodies.len() == self.ratios.len()
+    }
+
     pub fn get_token_id(&self, custody: &Pubkey) -> Result<usize> {
-        self.tokens
+        self.custodies
             .iter()
-            .position(|&k| k.custody == *custody)
+            .position(|&k| k == *custody)
             .ok_or_else(|| PerpetualsError::UnsupportedToken.into())
     }
 
@@ -317,9 +354,9 @@ impl Pool {
     ) -> Result<bool> {
         let new_ratio = self.get_new_ratio(amount_add, amount_remove, custody, token_price)?;
 
-        if new_ratio < self.tokens[token_id].min_ratio {
+        if new_ratio < self.ratios[token_id].min {
             Ok(new_ratio >= self.get_current_ratio(custody, token_price)?)
-        } else if new_ratio > self.tokens[token_id].max_ratio {
+        } else if new_ratio > self.ratios[token_id].max {
             Ok(new_ratio <= self.get_current_ratio(custody, token_price)?)
         } else {
             Ok(true)
@@ -587,13 +624,13 @@ impl Pool {
         curtime: i64,
     ) -> Result<u128> {
         let mut pool_amount_usd: u128 = 0;
-        for (idx, &token) in self.tokens.iter().enumerate() {
-            let oracle_idx = idx + self.tokens.len();
+        for (idx, &custody) in self.custodies.iter().enumerate() {
+            let oracle_idx = idx + self.custodies.len();
             if oracle_idx >= accounts.len() {
                 return Err(ProgramError::NotEnoughAccountKeys.into());
             }
 
-            require_keys_eq!(accounts[idx].key(), token.custody);
+            require_keys_eq!(accounts[idx].key(), custody);
             let custody = Account::<Custody>::try_from(&accounts[idx])?;
             require_keys_eq!(accounts[oracle_idx].key(), custody.oracle.oracle_account);
 
@@ -814,10 +851,10 @@ impl Pool {
         if custody.fees.mode == FeesMode::Fixed {
             return Self::get_fee_amount(base_fee, std::cmp::max(amount_add, amount_remove));
         }
-        let token = &self.tokens[token_id];
+        let ratios = &self.ratios[token_id];
         let new_ratio = self.get_new_ratio(amount_add, amount_remove, custody, token_price)?;
 
-        let fee = match new_ratio.cmp(&token.target_ratio) {
+        let fee = match new_ratio.cmp(&ratios.target) {
             Ordering::Equal => base_fee,
             Ordering::Greater => {
                 let max_fee_change = math::checked_as_u64(math::checked_div(
@@ -825,7 +862,7 @@ impl Pool {
                     Perpetuals::BPS_POWER,
                 )?)?;
 
-                if token.max_ratio <= token.target_ratio || token.max_ratio <= new_ratio {
+                if ratios.max <= ratios.target || ratios.max <= new_ratio {
                     math::checked_add(base_fee, max_fee_change)?
                 } else {
                     math::checked_add(
@@ -833,12 +870,12 @@ impl Pool {
                         math::checked_as_u64(math::checked_ceil_div(
                             math::checked_mul(
                                 math::checked_sub(
-                                    std::cmp::min(token.max_ratio, new_ratio),
-                                    token.target_ratio,
+                                    std::cmp::min(ratios.max, new_ratio),
+                                    ratios.target,
                                 )? as u128,
                                 max_fee_change as u128,
                             )?,
-                            math::checked_sub(token.max_ratio, token.target_ratio)? as u128,
+                            math::checked_sub(ratios.max, ratios.target)? as u128,
                         )?)?,
                     )?
                 }
@@ -849,18 +886,16 @@ impl Pool {
                     Perpetuals::BPS_POWER,
                 )?)?;
 
-                if token.target_ratio <= token.min_ratio || token.max_ratio <= new_ratio {
+                if ratios.target <= ratios.min || ratios.max <= new_ratio {
                     math::checked_sub(base_fee, max_fee_change)?
                 } else {
                     let fee_reduce = math::checked_as_u64(math::checked_ceil_div(
                         math::checked_mul(
-                            math::checked_sub(
-                                token.target_ratio,
-                                std::cmp::max(token.min_ratio, new_ratio),
-                            )? as u128,
+                            math::checked_sub(ratios.target, std::cmp::max(ratios.min, new_ratio))?
+                                as u128,
                             max_fee_change as u128,
                         )?,
-                        math::checked_sub(token.target_ratio, token.min_ratio)? as u128,
+                        math::checked_sub(ratios.target, ratios.min)? as u128,
                     )?)?;
                     if base_fee > fee_reduce {
                         math::checked_sub(base_fee, fee_reduce)?
@@ -885,11 +920,10 @@ mod test {
     };
 
     fn get_fixture() -> (Pool, Custody, Position, OraclePrice, OraclePrice) {
-        let token = PoolToken {
-            custody: Pubkey::default(),
-            target_ratio: 5000,
-            min_ratio: 1000,
-            max_ratio: 9000,
+        let ratios = TokenRatios {
+            target: 5000,
+            min: 1000,
+            max: 9000,
         };
 
         let oracle = OracleParams {
@@ -971,7 +1005,7 @@ mod test {
         (
             Pool {
                 name: "Test Pool".to_string(),
-                tokens: vec![token, token],
+                ratios: vec![ratios, ratios],
                 ..Default::default()
             },
             custody,
@@ -1106,7 +1140,7 @@ mod test {
             .unwrap()
         );
 
-        pool.tokens[0].max_ratio = 10001;
+        pool.ratios[0].max = 10001;
         assert_eq!(
             scale_f64(0.6, custody.decimals),
             pool.get_fee(
@@ -1120,7 +1154,7 @@ mod test {
             .unwrap()
         );
 
-        pool.tokens[0].max_ratio = 9000;
+        pool.ratios[0].max = 9000;
         pool.aum_usd = scale(5000000, Perpetuals::USD_DECIMALS) as u128;
         custody.assets.owned = scale(10000, custody.decimals);
         assert_eq!(

--- a/programs/perpetuals/tests/anchor/basic.ts
+++ b/programs/perpetuals/tests/anchor/basic.ts
@@ -113,7 +113,8 @@ describe("perpetuals", () => {
     let pool = await tc.program.account.pool.fetch(tc.pool.publicKey);
     let poolExpected = {
       name: "test pool",
-      tokens: [],
+      custodies: [],
+      ratios: [],
       aumUsd: new BN(0),
       bump: tc.pool.bump,
       lpTokenBump: pool.lpTokenBump,
@@ -176,11 +177,25 @@ describe("perpetuals", () => {
       slope2: new BN(120000),
       optimalUtilization: new BN(800000000),
     };
-    ratios = {
-      target: new BN(5000),
-      min: new BN(10),
-      max: new BN(20000),
-    };
+    ratios = [
+      {
+        target: new BN(5000),
+        min: new BN(10),
+        max: new BN(10000),
+      },
+      {
+        target: new BN(5000),
+        min: new BN(10),
+        max: new BN(10000),
+      },
+    ];
+    let ratios1 = [
+      {
+        target: new BN(10000),
+        min: new BN(10),
+        max: new BN(10000),
+      },
+    ];
     isStable = false;
     await tc.addCustody(
       tc.custodies[0],
@@ -190,7 +205,7 @@ describe("perpetuals", () => {
       permissions,
       fees,
       borrowRate,
-      ratios
+      ratios1
     );
 
     let token = await tc.program.account.custody.fetch(tc.custodies[0].custody);
@@ -319,7 +334,7 @@ describe("perpetuals", () => {
       ratios
     );
 
-    await tc.removeCustody(tc.custodies[1]);
+    await tc.removeCustody(tc.custodies[1], ratios1);
     tc.ensureFails(tc.program.account.custody.fetch(tc.custodies[1].custody));
 
     await tc.addCustody(
@@ -338,7 +353,7 @@ describe("perpetuals", () => {
     oracleConfig.maxPriceAgeSec = 90;
     permissions.allowPnlWithdrawal = false;
     fees.liquidation = new BN(200);
-    ratios.target = new BN(90);
+    ratios[0].min = new BN(90);
     await tc.setCustodyConfig(
       tc.custodies[0],
       isStable,

--- a/programs/perpetuals/tests/anchor/test_client.ts
+++ b/programs/perpetuals/tests/anchor/test_client.ts
@@ -503,9 +503,7 @@ export class TestClient {
             permissions,
             fees,
             borrowRate,
-            targetRatio: ratios.target,
-            minRatio: ratios.min,
-            maxRatio: ratios.max,
+            ratios,
           })
           .accounts({
             admin: this.admins[i].publicKey,
@@ -531,14 +529,14 @@ export class TestClient {
     }
   };
 
-  removeCustody = async (custody) => {
+  removeCustody = async (custody, ratios) => {
     let multisig = await this.program.account.multisig.fetch(
       this.multisig.publicKey
     );
     for (let i = 0; i < multisig.minSignatures; ++i) {
       try {
         await this.program.methods
-          .removeCustody({})
+          .removeCustody({ ratios })
           .accounts({
             admin: this.admins[i].publicKey,
             multisig: this.multisig.publicKey,
@@ -584,9 +582,7 @@ export class TestClient {
             permissions,
             fees,
             borrowRate,
-            targetRatio: ratios.target,
-            minRatio: ratios.min,
-            maxRatio: ratios.max,
+            ratios,
           })
           .accounts({
             admin: this.admins[i].publicKey,

--- a/programs/perpetuals/tests/native/instructions/test_add_custody.rs
+++ b/programs/perpetuals/tests/native/instructions/test_add_custody.rs
@@ -67,7 +67,9 @@ pub async fn test_add_custody(
         utils::create_and_execute_perpetuals_ix(
             program_test_ctx,
             accounts_meta,
-            perpetuals::instruction::AddCustody { params },
+            perpetuals::instruction::AddCustody {
+                params: params.clone(),
+            },
             Some(&payer.pubkey()),
             &[admin, payer, signer],
         )
@@ -101,12 +103,13 @@ pub async fn test_add_custody(
     // Check pool token
     {
         let idx = pool_account.get_token_id(&custody_pda).unwrap();
-        let pool_token = pool_account.tokens[idx];
+        let custody = pool_account.custodies[idx];
+        let ratios = pool_account.ratios[idx];
 
-        assert_eq!(pool_token.custody, custody_pda);
-        assert_eq!(pool_token.target_ratio, params.target_ratio);
-        assert_eq!(pool_token.min_ratio, params.min_ratio);
-        assert_eq!(pool_token.max_ratio, params.max_ratio);
+        assert_eq!(custody, custody_pda);
+        assert_eq!(ratios.target, params.ratios[idx].target);
+        assert_eq!(ratios.min, params.ratios[idx].min);
+        assert_eq!(ratios.max, params.ratios[idx].max);
     }
 
     Ok((custody_pda, custody_bump))

--- a/programs/perpetuals/tests/native/instructions/test_add_liquidity.rs
+++ b/programs/perpetuals/tests/native/instructions/test_add_liquidity.rs
@@ -73,18 +73,17 @@ pub async fn test_add_liquidity(
         let pool_account = utils::get_account::<Pool>(program_test_ctx, *pool_pda).await;
 
         // For each token, add custody account as remaining_account
-        for token in pool_account.tokens.as_slice() {
+        for custody in &pool_account.custodies {
             accounts_meta.push(AccountMeta {
-                pubkey: token.custody,
+                pubkey: *custody,
                 is_signer: false,
                 is_writable: false,
             });
         }
 
         // For each token, add custody oracle account as remaining_account
-        for token in pool_account.tokens.as_slice() {
-            let custody_account =
-                utils::get_account::<Custody>(program_test_ctx, token.custody).await;
+        for custody in &pool_account.custodies {
+            let custody_account = utils::get_account::<Custody>(program_test_ctx, *custody).await;
 
             accounts_meta.push(AccountMeta {
                 pubkey: custody_account.oracle.oracle_account,

--- a/programs/perpetuals/tests/native/instructions/test_remove_liquidity.rs
+++ b/programs/perpetuals/tests/native/instructions/test_remove_liquidity.rs
@@ -74,18 +74,17 @@ pub async fn test_remove_liquidity(
         let pool_account = utils::get_account::<Pool>(program_test_ctx, *pool_pda).await;
 
         // For each token, add custody account as remaining_account
-        for token in pool_account.tokens.as_slice() {
+        for custody in &pool_account.custodies {
             accounts_meta.push(AccountMeta {
-                pubkey: token.custody,
+                pubkey: *custody,
                 is_signer: false,
                 is_writable: false,
             });
         }
 
         // For each token, add custody oracle account as remaining_account
-        for token in pool_account.tokens.as_slice() {
-            let custody_account =
-                utils::get_account::<Custody>(program_test_ctx, token.custody).await;
+        for custody in &pool_account.custodies {
+            let custody_account = utils::get_account::<Custody>(program_test_ctx, *custody).await;
 
             accounts_meta.push(AccountMeta {
                 pubkey: custody_account.oracle.oracle_account,

--- a/programs/perpetuals/tests/native/instructions/test_set_custody_config.rs
+++ b/programs/perpetuals/tests/native/instructions/test_set_custody_config.rs
@@ -52,7 +52,9 @@ pub async fn test_set_custody_config(
         utils::create_and_execute_perpetuals_ix(
             program_test_ctx,
             accounts_meta,
-            perpetuals::instruction::SetCustodyConfig { params },
+            perpetuals::instruction::SetCustodyConfig {
+                params: params.clone(),
+            },
             Some(&payer.pubkey()),
             &[admin, payer, signer],
         )


### PR DESCRIPTION
Target token ratios should always add up to 1. Right now token ratios are set per custody when it is initialized or updated. But every time it happens ratios for all other tokens in the pool must be updated as well. Same when a custody is removed. Otherwise it will lead to an inconsistent pool parameters. This PR ensures that all operations on custodies (add/update/remove) also atomically update all token ratios to proper values. And required checks have been added to the pool.