### PR TITLE
Update get_liquidation_price

### DIFF
--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -231,10 +231,19 @@ async function getLiquidationPrice(
   wallet: PublicKey,
   poolName: string,
   tokenMint: PublicKey,
-  side: PositionSide
+  side: PositionSide,
+  addCollateral: BN,
+  removeCollateral: BN
 ) {
   client.prettyPrint(
-    await client.getLiquidationPrice(wallet, poolName, tokenMint, side)
+    await client.getLiquidationPrice(
+      wallet,
+      poolName,
+      tokenMint,
+      side,
+      addCollateral,
+      removeCollateral
+    )
   );
 }
 
@@ -540,12 +549,16 @@ async function getAum(poolName: string) {
     .argument("<string>", "Pool name")
     .argument("<pubkey>", "Token mint")
     .argument("<string>", "Position side (long / short)")
-    .action(async (wallet, poolName, tokenMint, side) => {
+    .option("-a, --add-collateral <bigint>", "Collateral to add")
+    .option("-r, --remove-collateral <bigint>", "Collateral to remove")
+    .action(async (wallet, poolName, tokenMint, side, options) => {
       await getLiquidationPrice(
         new PublicKey(wallet),
         poolName,
         new PublicKey(tokenMint),
-        side
+        side,
+        new BN(options.addCollateral),
+        new BN(options.removeCollateral)
       );
     });
 

--- a/app/src/client.ts
+++ b/app/src/client.ts
@@ -629,10 +629,15 @@ export class PerpetualsClient {
     wallet: PublicKey,
     poolName: string,
     tokenMint: PublicKey,
-    side: PositionSide
+    side: PositionSide,
+    addCollateral: typeof BN,
+    removeCollateral: typeof BN
   ) => {
     return await this.program.methods
-      .getLiquidationPrice({})
+      .getLiquidationPrice({
+        addCollateral,
+        removeCollateral,
+      })
       .accounts({
         perpetuals: this.perpetuals.publicKey,
         pool: this.getPoolKey(poolName),


### PR DESCRIPTION
It is useful to be able to change the collateral amount of the position when calling get_liquidation_price() getter. In particular it is needed for the UI to display expected liquidation price in the collateral change dialog.