### PR TITLE
Limit usage of the raw price

### DIFF
--- a/programs/perpetuals/src/instructions/add_collateral.rs
+++ b/programs/perpetuals/src/instructions/add_collateral.rs
@@ -125,25 +125,22 @@ pub fn add_collateral(ctx: Context<AddCollateral>, params: &AddCollateralParams)
         custody.pricing.use_ema,
     )?;
 
+    let min_price = if token_price < token_ema_price {
+        token_price
+    } else {
+        token_ema_price
+    };
+
     // compute fee
     let fee_amount =
-        pool.get_add_liquidity_fee(token_id, params.collateral, custody, &token_price)?;
+        pool.get_add_liquidity_fee(token_id, params.collateral, custody, &token_ema_price)?;
     msg!("Collected fee: {}", fee_amount);
 
     // compute amount to transfer
     let transfer_amount = math::checked_add(params.collateral, fee_amount)?;
-    let collateral_usd = token_price.get_asset_amount_usd(params.collateral, custody.decimals)?;
+    let collateral_usd = min_price.get_asset_amount_usd(params.collateral, custody.decimals)?;
     msg!("Amount in: {}", transfer_amount);
     msg!("Collateral added in USD: {}", collateral_usd);
-
-    // check pool constraints
-    msg!("Check pool constraints");
-    let protocol_fee = Pool::get_fee_amount(custody.fees.protocol_share, fee_amount)?;
-    let deposit_amount = math::checked_sub(transfer_amount, protocol_fee)?;
-    require!(
-        pool.check_token_ratio(token_id, deposit_amount, 0, custody, &token_price)?,
-        PerpetualsError::TokenRatioOutOfRange
-    );
 
     // update existing position
     msg!("Update existing position");
@@ -180,9 +177,11 @@ pub fn add_collateral(ctx: Context<AddCollateral>, params: &AddCollateralParams)
     custody.collected_fees.open_position_usd = custody
         .collected_fees
         .open_position_usd
-        .wrapping_add(token_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
+        .wrapping_add(token_ema_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
 
     custody.assets.collateral = math::checked_add(custody.assets.collateral, params.collateral)?;
+
+    let protocol_fee = Pool::get_fee_amount(custody.fees.protocol_share, fee_amount)?;
     custody.assets.protocol_fees = math::checked_add(custody.assets.protocol_fees, protocol_fee)?;
 
     custody.add_collateral(position.side, collateral_usd)?;

--- a/programs/perpetuals/src/instructions/close_position.rs
+++ b/programs/perpetuals/src/instructions/close_position.rs
@@ -185,7 +185,7 @@ pub fn close_position(ctx: Context<ClosePosition>, params: &ClosePositionParams)
     custody.collected_fees.close_position_usd = custody
         .collected_fees
         .close_position_usd
-        .wrapping_add(token_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
+        .wrapping_add(token_ema_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
 
     custody.volume_stats.close_position_usd = custody
         .volume_stats

--- a/programs/perpetuals/src/instructions/liquidate.rs
+++ b/programs/perpetuals/src/instructions/liquidate.rs
@@ -201,7 +201,7 @@ pub fn liquidate(ctx: Context<Liquidate>, _params: &LiquidateParams) -> Result<(
     custody.collected_fees.liquidation_usd = custody
         .collected_fees
         .liquidation_usd
-        .wrapping_add(token_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
+        .wrapping_add(token_ema_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
 
     custody.volume_stats.liquidation_usd =
         math::checked_add(custody.volume_stats.liquidation_usd, position.size_usd)?;

--- a/programs/perpetuals/src/instructions/remove_collateral.rs
+++ b/programs/perpetuals/src/instructions/remove_collateral.rs
@@ -136,9 +136,16 @@ pub fn remove_collateral(
         custody.pricing.use_ema,
     )?;
 
+    let max_price = if token_price > token_ema_price {
+        token_price
+    } else {
+        token_ema_price
+    };
+
     // compute fee
-    let collateral = token_price.get_token_amount(params.collateral_usd, custody.decimals)?;
-    let fee_amount = pool.get_remove_liquidity_fee(token_id, collateral, custody, &token_price)?;
+    let collateral = max_price.get_token_amount(params.collateral_usd, custody.decimals)?;
+    let fee_amount =
+        pool.get_remove_liquidity_fee(token_id, collateral, custody, &token_ema_price)?;
     msg!("Collected fee: {}", fee_amount);
 
     // compute amount to transfer
@@ -147,15 +154,6 @@ pub fn remove_collateral(
     }
     let transfer_amount = math::checked_sub(collateral, fee_amount)?;
     msg!("Amount out: {}", transfer_amount);
-
-    // check pool constraints
-    msg!("Check pool constraints");
-    let protocol_fee = Pool::get_fee_amount(custody.fees.protocol_share, fee_amount)?;
-    let withdrawal_amount = math::checked_add(transfer_amount, protocol_fee)?;
-    require!(
-        pool.check_token_ratio(token_id, 0, withdrawal_amount, custody, &token_price)?,
-        PerpetualsError::TokenRatioOutOfRange
-    );
 
     // update existing position
     msg!("Update existing position");
@@ -192,9 +190,11 @@ pub fn remove_collateral(
     custody.collected_fees.open_position_usd = custody
         .collected_fees
         .open_position_usd
-        .wrapping_add(token_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
+        .wrapping_add(token_ema_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
 
     custody.assets.collateral = math::checked_sub(custody.assets.collateral, collateral)?;
+
+    let protocol_fee = Pool::get_fee_amount(custody.fees.protocol_share, fee_amount)?;
     custody.assets.protocol_fees = math::checked_add(custody.assets.protocol_fees, protocol_fee)?;
 
     custody.remove_collateral(position.side, params.collateral_usd)?;

--- a/programs/perpetuals/src/instructions/remove_liquidity.rs
+++ b/programs/perpetuals/src/instructions/remove_liquidity.rs
@@ -144,6 +144,12 @@ pub fn remove_liquidity(
         custody.pricing.use_ema,
     )?;
 
+    let max_price = if token_price > token_ema_price {
+        token_price
+    } else {
+        token_ema_price
+    };
+
     let pool_amount_usd =
         pool.get_assets_under_management_usd(AumCalcMode::Min, ctx.remaining_accounts, curtime)?;
 
@@ -153,16 +159,11 @@ pub fn remove_liquidity(
         ctx.accounts.lp_token_mint.supply as u128,
     )?)?;
 
-    let max_price = if token_price > token_ema_price {
-        token_price
-    } else {
-        token_ema_price
-    };
     let remove_amount = max_price.get_token_amount(remove_amount_usd, custody.decimals)?;
 
     // calculate fee
     let fee_amount =
-        pool.get_remove_liquidity_fee(token_id, remove_amount, custody, &token_price)?;
+        pool.get_remove_liquidity_fee(token_id, remove_amount, custody, &token_ema_price)?;
     msg!("Collected fee: {}", fee_amount);
 
     let transfer_amount = math::checked_sub(remove_amount, fee_amount)?;
@@ -178,7 +179,7 @@ pub fn remove_liquidity(
     let protocol_fee = Pool::get_fee_amount(custody.fees.protocol_share, fee_amount)?;
     let withdrawal_amount = math::checked_add(transfer_amount, protocol_fee)?;
     require!(
-        pool.check_token_ratio(token_id, 0, withdrawal_amount, custody, &token_price)?,
+        pool.check_token_ratio(token_id, 0, withdrawal_amount, custody, &token_ema_price)?,
         PerpetualsError::TokenRatioOutOfRange
     );
 
@@ -212,7 +213,7 @@ pub fn remove_liquidity(
     custody.collected_fees.remove_liquidity_usd = custody
         .collected_fees
         .remove_liquidity_usd
-        .wrapping_add(token_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
+        .wrapping_add(token_ema_price.get_asset_amount_usd(fee_amount, custody.decimals)?);
 
     custody.volume_stats.remove_liquidity_usd = custody
         .volume_stats


### PR DESCRIPTION
Limit usage of raw price. Either use min/max or ema for fees. Ema is chosen for fees because fees don't necessarily change in the same direction with price but rather depend on token ratios change.

closes #43
also addresses original description in #18